### PR TITLE
Add makefile and github action to build source

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,20 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        go-version: [1.15.x]
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Test
+      run: make build

--- a/.gitignore
+++ b/.gitignore
@@ -11,8 +11,8 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
-# Dependency directories (remove the comment below to include it)
-# vendor/
+# Binary
+bin/
 
 # Ignore token.json
 token.json

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+BINDIR:=bin
+BIN:=$(BINDIR)/autocmp
+
+.PHONY: all
+all: build
+
+.PHONY: build
+build: $(BIN)
+
+$(BIN): $(BINDIR) main.go 
+	go build -o $(BIN) .
+
+$(BINDIR):
+	mkdir -p $(BINDIR)


### PR DESCRIPTION
This ensures that building is easy and that we don't break the build by adding
a simple GitHub action to do that.