### PR TITLE
Add unit tests and handle narratives for all control types

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Build & Test
 
 on: [push, pull_request]
 
@@ -16,5 +16,7 @@ jobs:
         go-version: ${{ matrix.go-version }}
     - name: Checkout code
       uses: actions/checkout@v2
-    - name: Test
+    - name: Build
       run: make build
+    - name: Test
+      run: make test-unit

--- a/Makefile
+++ b/Makefile
@@ -18,3 +18,7 @@ $(BINDIR):
 .PHONY: run
 run: build
 	./$(BIN)
+
+.PHONY: test-unit
+test-unit:
+	go test -v -race ./...

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -85,6 +85,7 @@ func (p *Parser) parseControl(control string) (opencontrol.OpenControlEntry, err
 	if p.simpleCtrl.MatchString(ctrlNw) {
 		matches := p.simpleCtrl.FindStringSubmatch(ctrlNw)
 		ctrl.ControlKey = getControlKey(matches)
+		ctrl.Narrative = append(ctrl.Narrative, getTextOnlyNarrative())
 		return ctrl, nil
 	} else if p.ctrlEnh.MatchString(ctrlNw) {
 		matches := p.ctrlEnh.FindStringSubmatch(ctrlNw)
@@ -94,10 +95,12 @@ func (p *Parser) parseControl(control string) (opencontrol.OpenControlEntry, err
 	} else if p.simpleSubCtrl.MatchString(ctrlNw) {
 		matches := p.simpleSubCtrl.FindStringSubmatch(ctrlNw)
 		ctrl.ControlKey = getSubControlKey(matches)
+		ctrl.Narrative = append(ctrl.Narrative, getTextOnlyNarrative())
 		return ctrl, nil
 	} else if p.subCtrlEnh.MatchString(ctrlNw) {
 		matches := p.subCtrlEnh.FindStringSubmatch(ctrlNw)
 		ctrl.ControlKey = getSubControlKey(matches)
+		ctrl.Narrative = append(ctrl.Narrative, getNarrativeForEnhancement(matches[4]))
 		return ctrl, nil
 	} else {
 		// no match
@@ -117,10 +120,18 @@ func getSubControlKey(matches []string) string {
 	return fmt.Sprintf("%s-%s %s", matches[1], matches[2], matches[3])
 }
 
+func getTextOnlyNarrative() opencontrol.NarrativeEntry {
+	// TODO(jaosorior): get text from spreadsheet
+	return opencontrol.NarrativeEntry{
+		Text: "Text only",
+	}
+}
+
 func getNarrativeForEnhancement(enhancement string) opencontrol.NarrativeEntry {
+	// TODO(jaosorior): get text from spreadsheet
 	return opencontrol.NarrativeEntry{
 		Key:  normalizeEnhacementKey(enhancement),
-		Text: "Foo",
+		Text: "Text for enhancement",
 	}
 }
 

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -1,0 +1,159 @@
+package parser
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/carlosmmatos/automate-compliance/internal/opencontrol"
+)
+
+func buildControlEntryWithDefaults(key string, n opencontrol.NarrativeEntry) opencontrol.OpenControlEntry {
+	oce := opencontrol.ControlEntryWithDefaults()
+	oce.ControlKey = key
+	oce.Narrative = append(oce.Narrative, n)
+	return oce
+}
+
+func TestParser_normalizeFamily(t *testing.T) {
+	type args struct {
+		family string
+	}
+
+	p := NewParser()
+
+	tests := []struct {
+		name string
+		args args
+		want opencontrol.Family
+	}{
+		{
+			"simple family", args{"ACCESS CONTROL"}, opencontrol.Family("ACCESS_CONTROL"),
+		},
+		{
+			"family with extra spaces", args{"ACCESS   CONTROL"}, opencontrol.Family("ACCESS_CONTROL"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := p.normalizeFamily(tt.args.family); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Parser.normalizeFamily() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParser_parseControl(t *testing.T) {
+	type args struct {
+		control string
+	}
+
+	p := NewParser()
+
+	tests := []struct {
+		name    string
+		args    args
+		want    opencontrol.OpenControlEntry
+		wantErr bool
+	}{
+		{
+			"Simple control is successfully parsed",
+			args{"AC-1"},
+			buildControlEntryWithDefaults("AC-1", opencontrol.NarrativeEntry{
+				Text: "Text only",
+			}),
+			false,
+		},
+		{
+			"Control with enhancement is successfully parsed",
+			args{"AC-2a."},
+			buildControlEntryWithDefaults("AC-2", opencontrol.NarrativeEntry{
+				Key:  "a",
+				Text: "Text for enhancement",
+			}),
+			false,
+		},
+		{
+			"Control with enhancement and sub-enhancement is successfully parsed",
+			args{"AC-2a.1."},
+			buildControlEntryWithDefaults("AC-2", opencontrol.NarrativeEntry{
+				Key:  "a.1",
+				Text: "Text for enhancement",
+			}),
+			false,
+		},
+		{
+			"Simple Sub-control is successfully parsed",
+			args{"AC-2 (1)"},
+			buildControlEntryWithDefaults("AC-2 (1)", opencontrol.NarrativeEntry{
+				Text: "Text only",
+			}),
+			false,
+		},
+		{
+			"Simple Sub-control with high number is successfully parsed",
+			args{"SC-42 (3)"},
+			buildControlEntryWithDefaults("SC-42 (3)", opencontrol.NarrativeEntry{
+				Text: "Text only",
+			}),
+			false,
+		},
+		{
+			// At some point there was a bug in which AC-2 (10) wasn't
+			// parsed properly. This ensures that such values are parsed.
+			"Simple Sub-control (above 9) is successfully parsed",
+			args{"AC-2 (21)"},
+			buildControlEntryWithDefaults("AC-2 (21)", opencontrol.NarrativeEntry{
+				Text: "Text only",
+			}),
+			false,
+		},
+		{
+			"Sub-control with enhancement is successfully parsed",
+			args{"AC-3 (3)(a)"},
+			buildControlEntryWithDefaults("AC-3 (3)", opencontrol.NarrativeEntry{
+				Key:  "a",
+				Text: "Text for enhancement",
+			}),
+			false,
+		},
+		{
+			"Sub-control with enhancement and sub-enhancement is successfully parsed",
+			args{"AC-3 (3)(b)(1)"},
+			buildControlEntryWithDefaults("AC-3 (3)", opencontrol.NarrativeEntry{
+				// TODO(jaosorior): What's the appropriate value here?
+				//                  I couldn't find examples... and so I
+				//                  left it at  just the enhancement number.
+				Key:  "b",
+				Text: "Text for enhancement",
+			}),
+			false,
+		},
+		{
+			"Sub-control with enhancement and extra spaces is successfully parsed",
+			args{"AC-3   (3)(a)"},
+			buildControlEntryWithDefaults("AC-3 (3)", opencontrol.NarrativeEntry{
+				Key:  "a",
+				Text: "Text for enhancement",
+			}),
+			false,
+		},
+		{
+			"Malformed control returns an error",
+			args{"SC-43a)"},
+			opencontrol.ControlEntryWithDefaults(),
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := p.parseControl(tt.args.control)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Parser.parseControl() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Parser.parseControl() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This adds simple unit tests for control and family parsing. Thus
documenting a little more what's expected from parsing those controls.

This also handles narratives a little better. Note that currently there
are placeholders for the narratives so we are able to test them. We
should replace these with actual texts and pass these through the
appropraite functions. This will require us to standardize on where in
the spreadsheet should these texts go.

Finally, this adds the unit tests run to the workflow

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>